### PR TITLE
Contributing Violation Metrics Export Sidecar for Gatekeeper

### DIFF
--- a/gatekeeper_mtail_violations_exporter/Dockerfile
+++ b/gatekeeper_mtail_violations_exporter/Dockerfile
@@ -1,0 +1,19 @@
+# build mtail binary
+FROM golang:alpine AS builder
+
+WORKDIR /go/src/github.com/google/mtail
+
+# mtail repo includes a tag for each "release"
+# build the mtail binary using the rc36 release
+RUN apk add --update --no-cache --virtual build-dependencies git make \
+ && git clone https://github.com/google/mtail /go/src/github.com/google/mtail \
+ && git checkout v3.0.0-rc36 \
+ && make depclean && make install_deps \
+ && PREFIX=/go make STATIC=y -B install
+
+# package mtail binary in a small scratch image (total size ~12MB)
+FROM scratch
+COPY --from=builder /go/bin/mtail /usr/bin/mtail
+ENTRYPOINT ["/usr/bin/mtail"]
+EXPOSE 3903
+WORKDIR /tmp

--- a/gatekeeper_mtail_violations_exporter/Makefile
+++ b/gatekeeper_mtail_violations_exporter/Makefile
@@ -1,0 +1,14 @@
+VERSION := 1.0
+REPOSITORY := openpolicyagent/gatekeeper_mtail_violatons_exporter
+
+clean:
+	rm -fr target
+
+build: image
+
+image:
+	docker build -t $(REPOSITORY):$(VERSION) -t openpolicyagent/mtail_violatons_exporter:latest .
+
+push: build
+	docker push $(REPOSITORY):$(VERSION)
+	docker push $(REPOSITORY):latest

--- a/gatekeeper_mtail_violations_exporter/README.md
+++ b/gatekeeper_mtail_violations_exporter/README.md
@@ -1,0 +1,27 @@
+# Gatekeeper Mtail Violations Exporter
+The configurations contained here will install Gatekeeper, adding a sidecar which reads Gatekeeper's audit loop logs and exposes violations on a prometheus scrape point.
+
+
+## Setup
+1. Run `kustomize build . | kubectl apply -f -` to deploy
+
+## Container Runtimes
+The default configuration for these manifests is for Docker. If you're using another runtime you will need to updated the log locations 
+
+## Example violations
+
+```
+opa_violations{constraint_kind="MyConstraint",
+               constraint_name="my-constraint",
+               context="pod:violating-pod",
+               msgid="deployment-manifest-violates-constraint",
+               resource_kind="Deployment",
+               resource_name="MyDeployment",
+               resource_namespace="my-namespace"}
+```
+
+## Storage Considerations
+The configs provided here include prometheus scrape annotations. If you'd prefer to use a [Service Monitor](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#related-resources) you will need to update the configurations here. If you are using another TSDB you may need to adjust these configurations according to the DB's specifications.
+
+### Performance
+Usage of this operator assumes your TSDB is able to handle as many timeseries as you have policies. 

--- a/gatekeeper_mtail_violations_exporter/gatekeeper.mtail
+++ b/gatekeeper_mtail_violations_exporter/gatekeeper.mtail
@@ -1,0 +1,45 @@
+# model the gauge based on labels
+gauge opa_violations by constraint_kind, constraint_name, resource_kind, resource_namespace, resource_name, msgid, context
+
+# temporary variable to store message id
+text msgid 
+
+# temporary variable to store message context
+text context
+
+# pattern for opa violation attributes
+const VIOLATION /{.*\\"constraint_kind\\"\s*:\s*\\"(?P<constraint_kind>.*?)\\".*\\"constraint_name\\"\s*:\s*\\"(?P<constraint_name>.*?)\\".*\\"resource_kind\\"\s*:\s*\\"(?P<resource_kind>.*?)\\".*\\"resource_namespace\\"\s*:\s*\\"(?P<resource_namespace>.*?)\\".*\\"resource_name\\"\s*:\s*\\"(?P<resource_name>.*?)\\".*}/
+
+# pattern for custom message
+const MESSAGE /msgid=(?P<msgid>.*?)\s+context=(?P<context>.*?)\s+/
+
+# pattern for violation_audited event
+const VIOLATION_AUDITED /violation_audited/
+
+# match pattern violation_audited in gatekeeper log ("event_type": "violation_audited")
+VIOLATION_AUDITED {
+
+  # initialize temporary variables
+  msgid = "na"
+  context = "na"
+  
+  # extract msgid and context if present
+  MESSAGE {
+    msgid = $msgid
+    context = $context
+  }
+
+  # extract matching groups that are used as labels for the gauge
+  VIOLATION {
+
+    # set the gauge value for current metrics to 1
+    opa_violations[$constraint_kind,$constraint_name,$resource_kind,$resource_namespace,$resource_name,msgid,context] = 1
+
+    # set current gauge to be garbage collected after a set interval to avoid stale metrics
+    # Interval should be greater than (prometheus scrape interval) + (audit interval) + (audit runtime) [30s + 1hour + 300s]
+    # to avoid gaps in metrics.
+    del opa_violations[$constraint_kind,$constraint_name,$resource_kind,$resource_namespace,$resource_name,msgid,context] after 3930s
+
+  }
+
+}

--- a/gatekeeper_mtail_violations_exporter/kustomization.yaml
+++ b/gatekeeper_mtail_violations_exporter/kustomization.yaml
@@ -1,0 +1,18 @@
+bases:
+  - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.3/deploy/gatekeeper.yaml
+
+resources:
+  - mtail_service.yaml
+
+patchesStrategicMerge:
+  - mtail_sidecar_patch.yaml
+
+configMapGenerator:
+  - name: mtail-config
+    files:
+      - gatekeeper.mtail
+
+images:
+ - name: mtail-gatekeeper-sidecar
+   newName: openpolicyagent/gatekeeper_mtail_violatons_exporter
+   newTag: latest

--- a/gatekeeper_mtail_violations_exporter/mtail_service.yaml
+++ b/gatekeeper_mtail_violations_exporter/mtail_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mtail-service
+  namespace: gatekeeper-system
+  annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port:   '3903'
+spec:
+  selector: 
+    control-plane: controller-manager
+    gatekeeper.sh/system: "yes"
+    gatekeeper.sh/operation: audit
+  type: ClusterIP  
+  ports:
+    - port: 3903
+      targetPort: 3903

--- a/gatekeeper_mtail_violations_exporter/mtail_sidecar_patch.yaml
+++ b/gatekeeper_mtail_violations_exporter/mtail_sidecar_patch.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '3903'
+    spec:
+      containers:
+      - name: mtail
+        args:
+        - -logtostderr
+        - -expired_metrics_gc_interval
+        - 30s
+        - -v
+        - "1" 
+        - -progs 
+        - /config
+        - -logs 
+        # container you want to tail the logs for
+        # /var/log/containers/<deployment>*<container name>*.log
+        # assumes you are only running one gatekeeper per cluster
+        - /var/log/containers/gatekeeper-audit-manager*manager*.log
+        # image label should match the label applied in the mtail-image pipeline job, and
+        # the mtail version checked out in the dockerfile
+        image: mtail-gatekeeper-sidecar
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+      volumes:
+      - name: config-volume
+        configMap:
+          # Provide the name of the ConfigMap containing the .mtail files
+          name: mtail-config
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers


### PR DESCRIPTION
At T-Mobile we use this sidecar to scrape the gatekeeper audit-loop logs from the audit container and then expose them on a prometheus metrics endpoint, we'd like to contribute it back for anyone who is looking to use this or a similar pattern for getting audited violation details out of Gatekeeper.

Contained in this PR is:

1. A Dockerfile for building the mtail image
2. Mtail code largely written by @ghsbhatia 
3.  a `kustomization.yaml` and patches to deploy gatekeeper with the sidecar.